### PR TITLE
fix bootnodes

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1175,8 +1175,6 @@ func setBootstrapNodes(ctx *cli.Context, cfg *p2p.Config) {
 			urls = params.HoleskyBootnodes
 		case ctx.Bool(SepoliaFlag.Name):
 			urls = params.SepoliaBootnodes
-		case ctx.Uint64(NetworkIdFlag.Name) == 3335:
-			urls = params.BetaTestnetBootnodes
 		}
 	}
 	cfg.BootstrapNodes = mustParseBootnodes(urls)
@@ -1213,6 +1211,8 @@ func setBootstrapNodesV5(ctx *cli.Context, cfg *p2p.Config) {
 		} else {
 			urls = params.V5OPTestnetBootnodes
 		}
+	case ctx.Uint64(NetworkIdFlag.Name) == 3335:
+		urls = params.BetaTestnetBootnodes
 	}
 
 	cfg.BootstrapNodesV5 = make([]*enode.Node, 0, len(urls))


### PR DESCRIPTION
The default enabled p2p is discv5, not discv4.

Fixes https://github.com/QuarkChain/op-geth/issues/4 .