### PR TITLE
node: Enable debug rpc in authrpc if enabled in http (#512)

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -463,6 +463,9 @@ func (n *Node) startRPC() error {
 		if slices.Contains(n.config.HTTPModules, "miner") {
 			authModules = append(authModules, "miner")
 		}
+		if slices.Contains(n.config.HTTPModules, "debug") {
+			authModules = append(authModules, "debug")
+		}
 
 		// Enable auth via HTTP
 		server := n.httpAuth


### PR DESCRIPTION
This PR cherry-picks an upstream PR: https://github.com/ethereum-optimism/op-geth/pull/512

Otherwise newly started op-node by opup will fail like this:

```
t=2025-04-21T12:56:34+0000 lvl=crit msg="Application failed" message="failed to setup: unable to create the rollup node: failed to init L2: failed to load or fetch chain config for id 42069: fetching: the method debug_chainConfig does not exist/is not available"
```

It's already on `beta_testnet` branch, but not on `op-es` .