### PR TITLE
fix initGenesis

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -235,7 +235,7 @@ func initGenesis(ctx *cli.Context) error {
 		utils.Fatalf("Failed to write genesis block: %v", err)
 	}
 	if compatErr != nil {
-		utils.Fatalf("Failed to write chain config: %v", err)
+		utils.Fatalf("Failed to write chain config: %v", compatErr)
 	}
 	log.Info("Successfully wrote genesis state", "database", "chaindata", "hash", hash)
 

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -230,9 +230,12 @@ func initGenesis(ctx *cli.Context) error {
 	triedb := utils.MakeTrieDatabase(ctx, chaindb, ctx.Bool(utils.CachePreimagesFlag.Name), false, genesis.IsVerkle())
 	defer triedb.Close()
 
-	_, hash, _, err := core.SetupGenesisBlockWithOverride(chaindb, triedb, genesis, &overrides)
+	_, hash, compatErr, err := core.SetupGenesisBlockWithOverride(chaindb, triedb, genesis, &overrides)
 	if err != nil {
 		utils.Fatalf("Failed to write genesis block: %v", err)
+	}
+	if compatErr != nil {
+		utils.Fatalf("Failed to write chain config: %v", err)
 	}
 	log.Info("Successfully wrote genesis state", "database", "chaindata", "hash", hash)
 


### PR DESCRIPTION
This PR cherry-picks a [fix](https://github.com/ethereum/go-ethereum/pull/31743) for `geth init` which has already been accepted by go-ethereum.

Before this fix, we may think some chain configs have already been applied by `geth init`, but in fact it's not.

