### PR TITLE
add InboxContractConfig to superchain for gamma_testnet

### DIFF
--- a/superchain/types.go
+++ b/superchain/types.go
@@ -4,6 +4,10 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
+type InboxContractConfig struct {
+	UseInboxContract bool `toml:"use_inbox_contract,omitempty"`
+}
+
 type ChainConfig struct {
 	Name                 string       `toml:"name"`
 	PublicRPC            string       `toml:"public_rpc"`
@@ -24,6 +28,8 @@ type ChainConfig struct {
 	Hardforks         HardforkConfig  `toml:"hardforks"`
 	Interop           *Interop        `toml:"interop,omitempty"`
 	Optimism          *OptimismConfig `toml:"optimism,omitempty"`
+
+	InboxContractConfig *InboxContractConfig `toml:"inbox_contract_config,omitempty"`
 
 	AltDA *AltDAConfig `toml:"alt_da,omitempty"`
 


### PR DESCRIPTION
The [previous](https://github.com/QuarkChain/op-geth/pull/30) PR only added L2Blob/SoulGasToken configs to super chain, we also need the `InboxContractConfig` for [`LoadOPStackRollupConfig`](https://github.com/QuarkChain/optimism/blob/5f228734277013dda6f6afb9bea1d8621c1d4c47/op-node/rollup/superchain.go#L25).

Another pr will update the optimism repo accordingly.