### PR TITLE
CircleCI: fix op-program-compat

### DIFF
--- a/consensus/misc/eip4844/eip4844.go
+++ b/consensus/misc/eip4844/eip4844.go
@@ -55,6 +55,9 @@ func (bc *BlobConfig) blobPrice(excessBlobGas uint64) *big.Int {
 
 func latestBlobConfig(cfg *params.ChainConfig, time uint64) *BlobConfig {
 	if cfg.BlobScheduleConfig == nil {
+		if cfg.IsL2Blob(cfg.LondonBlock, time) {
+			panic("blob schedule missing for L2Blob")
+		}
 		return nil
 	}
 	var (

--- a/consensus/misc/eip4844/eip4844.go
+++ b/consensus/misc/eip4844/eip4844.go
@@ -55,9 +55,6 @@ func (bc *BlobConfig) blobPrice(excessBlobGas uint64) *big.Int {
 
 func latestBlobConfig(cfg *params.ChainConfig, time uint64) *BlobConfig {
 	if cfg.BlobScheduleConfig == nil {
-		if cfg.IsL2Blob(cfg.LondonBlock, time) {
-			panic("blob schedule missing for L2Blob")
-		}
 		return nil
 	}
 	var (
@@ -145,6 +142,9 @@ func CalcExcessBlobGas(config *params.ChainConfig, parent *types.Header, headTim
 	isOsaka := config.IsOsaka(config.LondonBlock, headTimestamp)
 	bcfg := latestBlobConfig(config, headTimestamp)
 	if bcfg == nil {
+		if config.IsL2Blob(config.LondonBlock, headTimestamp) {
+			panic("failed to load blob config for L2Blob")
+		}
 		return 0
 	}
 	return calcExcessBlobGas(isOsaka, bcfg, parent)
@@ -197,6 +197,9 @@ func CalcBlobFee(config *params.ChainConfig, header *types.Header) *big.Int {
 
 	blobConfig := latestBlobConfig(config, header.Time)
 	if blobConfig == nil {
+		if config.IsL2Blob(config.LondonBlock, header.Time) {
+			panic("failed to load blob config for L2Blob")
+		}
 		return minBlobGasPrice
 	}
 	return blobConfig.blobBaseFee(*header.ExcessBlobGas)

--- a/consensus/misc/eip4844/eip4844.go
+++ b/consensus/misc/eip4844/eip4844.go
@@ -141,6 +141,9 @@ func CalcExcessBlobGas(config *params.ChainConfig, parent *types.Header, headTim
 
 	isOsaka := config.IsOsaka(config.LondonBlock, headTimestamp)
 	bcfg := latestBlobConfig(config, headTimestamp)
+	if bcfg == nil {
+		return 0
+	}
 	return calcExcessBlobGas(isOsaka, bcfg, parent)
 }
 
@@ -191,7 +194,7 @@ func CalcBlobFee(config *params.ChainConfig, header *types.Header) *big.Int {
 
 	blobConfig := latestBlobConfig(config, header.Time)
 	if blobConfig == nil {
-		panic("calculating blob fee on unsupported fork")
+		return minBlobGasPrice
 	}
 	return blobConfig.blobBaseFee(*header.ExcessBlobGas)
 }


### PR DESCRIPTION
Fix CircleCI [error](https://app.circleci.com/pipelines/circleci/9n5VnJ75qFpuj33eU2XAuA/UykduNDM3FCwRU5gTixTkY/54/workflows/718be64d-97be-4809-934c-10044113c061/jobs/1628) in op-program-compat
```
panic: runtime error: invalid memory address or nil pointer dereference
```

Can be verified locally on the optimism repo:
```
cd op-program
make verify-compat
```