### PR TITLE
skip refundIsthmusOperatorCost for estimate_gas

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -967,8 +967,9 @@ func (st *stateTransition) innerExecute() (*ExecutionResult, error) {
 				st.state.AddBalance(params.OptimismL1FeeRecipient, amtU256, tracing.BalanceIncreaseRewardTransactionFee)
 			}
 
-			if rules.IsOptimismIsthmus {
+			if rules.IsOptimismIsthmus && shouldCheckGasFormula {
 				// Operator Fee refunds are only applied if Isthmus is active and the transaction is *not* a deposit.
+				// Skip during gas estimation (when shouldCheckGasFormula is false) since operator cost wasn't pre-charged.
 				st.refundIsthmusOperatorCost()
 
 				operatorFeeCost := st.evm.Context.OperatorCostFunc(st.gasUsed(), st.evm.Context.Time)

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -965,20 +965,18 @@ func (st *stateTransition) innerExecute() (*ExecutionResult, error) {
 					amtU256 = st.collectNativeBalance(amtU256)
 					st.state.AddBalance(params.OptimismL1FeeRecipient, amtU256, tracing.BalanceIncreaseRewardTransactionFee)
 				}
-			}
 
-			if rules.IsOptimismIsthmus && shouldCheckGasFormula {
-				// Operator Fee refunds are only applied if Isthmus is active and the transaction is *not* a deposit.
-				// Skip during gas estimation (when shouldCheckGasFormula is false) since operator cost wasn't pre-charged.
-				st.refundIsthmusOperatorCost()
+				if rules.IsOptimismIsthmus {
+					// Operator Fee refunds are only applied if Isthmus is active and the transaction is *not* a deposit.
+					// Skip during gas estimation (when shouldCheckGasFormula is false) since operator cost wasn't pre-charged.
+					st.refundIsthmusOperatorCost()
 
-				operatorFeeCost := st.evm.Context.OperatorCostFunc(st.gasUsed(), st.evm.Context.Time)
-				st.operatorFee = operatorFeeCost.Clone()
-				operatorFeeCost = st.collectNativeBalance(operatorFeeCost)
-				st.state.AddBalance(params.OptimismOperatorFeeRecipient, operatorFeeCost, tracing.BalanceIncreaseRewardTransactionFee)
-			}
+					operatorFeeCost := st.evm.Context.OperatorCostFunc(st.gasUsed(), st.evm.Context.Time)
+					st.operatorFee = operatorFeeCost.Clone()
+					operatorFeeCost = st.collectNativeBalance(operatorFeeCost)
+					st.state.AddBalance(params.OptimismOperatorFeeRecipient, operatorFeeCost, tracing.BalanceIncreaseRewardTransactionFee)
+				}
 
-			if shouldCheckGasFormula {
 				if st.l1Fee == nil {
 					st.l1Fee = new(uint256.Int)
 				}

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -954,17 +954,17 @@ func (st *stateTransition) innerExecute() (*ExecutionResult, error) {
 
 			amtU256 = st.collectNativeBalance(amtU256)
 			st.state.AddBalance(params.OptimismBaseFeeRecipient, amtU256, tracing.BalanceIncreaseRewardTransactionFee)
-			if l1Cost := st.evm.Context.L1CostFunc(st.msg.RollupCostData, st.evm.Context.Time); l1Cost != nil {
-				amtU256, overflow = uint256.FromBig(l1Cost)
-				if overflow {
-					return nil, fmt.Errorf("optimism l1 cost overflows U256: %d", l1Cost)
-				}
-				if shouldCheckGasFormula {
+			if shouldCheckGasFormula {
+				if l1Cost := st.evm.Context.L1CostFunc(st.msg.RollupCostData, st.evm.Context.Time); l1Cost != nil {
+					amtU256, overflow = uint256.FromBig(l1Cost)
+					if overflow {
+						return nil, fmt.Errorf("optimism l1 cost overflows U256: %d", l1Cost)
+					}
 					st.l1Fee = amtU256.Clone()
-				}
 
-				amtU256 = st.collectNativeBalance(amtU256)
-				st.state.AddBalance(params.OptimismL1FeeRecipient, amtU256, tracing.BalanceIncreaseRewardTransactionFee)
+					amtU256 = st.collectNativeBalance(amtU256)
+					st.state.AddBalance(params.OptimismL1FeeRecipient, amtU256, tracing.BalanceIncreaseRewardTransactionFee)
+				}
 			}
 
 			if rules.IsOptimismIsthmus && shouldCheckGasFormula {


### PR DESCRIPTION
Skip `refundIsthmusOperatorCost()` during gas estimation (when `shouldCheckGasFormula` is false) since operator cost wasn't pre-charged.

Fixes https://github.com/QuarkChain/optimism/issues/130

**UPDATE**

l1 cost has the same issue, so also fixed.